### PR TITLE
Improved emote parsing in PrivateMessage

### DIFF
--- a/Sources/TwitchIRC/IncomingMessage/Emote.swift
+++ b/Sources/TwitchIRC/IncomingMessage/Emote.swift
@@ -1,0 +1,95 @@
+
+public struct Emote: Equatable {
+    /// The emote ID used in Twitch's API
+    public var id = String()
+    /// The emote name, which is the text used to represent the emote in a message
+    public var name = String()
+    /// The index in the message at which the emote starts
+    public var startIndex = Int()
+    /// The index in the message at which the emote ends
+    public var endIndex = Int()
+
+    public init() { }
+
+    init(
+        id: String,
+        name: String,
+        startIndex: Int,
+        endIndex: Int
+    ) {
+        self.id = id
+        self.name = name
+        self.startIndex = startIndex
+        self.endIndex = endIndex
+    }
+
+    public static func parse(from emoteString: String, and message: String) -> [Emote] {
+        /// First, we need to make sure we have an homogeneous array. In the message, emotes come as
+        /// a string that looks like `<id>:<start>-<end>/<id>:<start>-<end>`. However, when the same
+        /// emote repeats multiple times, it's more like
+        /// `<id>:<start>-<end>,<start>-<end>,<start>-<end>/<id>:<start>-<end>` and the parser has
+        /// issues giving it back as a list (the parser uses commas to sepparate, and doesn't take
+        /// the `/` into account).
+        ///
+        /// To solve this, we ask the parser to read it as a string and we treat the whole thing.
+        ///
+        /// Splitting by `/` returns an array like
+        /// `["<id>:<start>-<end>", "<start>-<end>", "<start>-<end>", "<id>:<start>-<end>"]`,
+        /// which makes it hard to treat all the elements the same since some of them have no `<id>`.
+        /// We solve this by using the last seen id as the id for elements that don't have one.
+        ///
+        /// Ater that, it's just a matter of parsing the indices and finding the equivalent text in
+        /// the chat message. With those, we can create our `EmoteReference` instance and save it.
+        var parsed: [Emote] = []
+
+        let emoteArray = emoteString.split(separator: "/")
+            .flatMap { $0.split(separator: ",") }
+            .map { String($0) }
+
+        var lastID: String? = nil
+        for emote in emoteArray {
+            /// This gives us either `["<id>", "<start>", "<end>"]` or `["<start>", "<end>"]`
+            var parts = emote.split(separator: ":")
+                .flatMap { $0.split(separator: "-") }
+                .map { String($0) }
+
+            /// If we have an id, save it
+            if parts.count == 3 {
+                lastID = parts.removeFirst()
+            }
+
+            /// Try and retrieve the parts and add them to our list of emotes
+            if let lastID = lastID,
+                let startIndex = Int(parts[0]),
+                let endIndex = Int(parts[1]),
+                let name = message[stringIn: startIndex...endIndex]
+            {
+                parsed.append(.init(
+                    id: lastID,
+                    name: name,
+                    startIndex: startIndex,
+                    endIndex: endIndex
+                ))
+            }
+        }
+
+        return parsed
+    }
+}
+
+extension String {
+    /// Subscripts a string using integers to create the equivalent indices.
+    subscript(stringIn range: ClosedRange<Int>) -> String? {
+        guard
+            let start = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
+            let end = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex)
+        else { return nil }
+
+        return String(self[start...end])
+    }
+}
+
+// MARK: - Sendable conformances
+#if swift(>=5.5)
+extension Emote: Sendable { }
+#endif

--- a/Sources/TwitchIRC/IncomingMessage/Emote.swift
+++ b/Sources/TwitchIRC/IncomingMessage/Emote.swift
@@ -1,5 +1,5 @@
 
-public struct Emote: Equatable {
+public struct Emote {
     /// The emote ID used in Twitch's API
     public var id = String()
     /// The emote name, which is the text used to represent the emote in a message

--- a/Sources/TwitchIRC/IncomingMessage/PrivateMessage.swift
+++ b/Sources/TwitchIRC/IncomingMessage/PrivateMessage.swift
@@ -1,31 +1,6 @@
 
 /// A Twitch `PRIVMSG` message.
 public struct PrivateMessage: MessageWithBadges {
-
-    public struct EmoteReference: Identifiable, Equatable {
-        /// The emote ID used in Twitch's API
-        public var id = String()
-        /// The emote name, which is the text used to represent the emote in a message
-        public var name = String()
-        /// The index in the message at which the emote starts
-        public var startIndex = Int()
-        /// The index in the message at which the emote ends
-        public var endIndex = Int()
-
-        public init() { }
-
-        init(
-            id: String,
-            name: String,
-            startIndex: Int,
-            endIndex: Int
-        ) {
-            self.id = id
-            self.name = name
-            self.startIndex = startIndex
-            self.endIndex = endIndex
-        }
-    }
     
     public struct ReplyParent {
         /// Replied user's display name with uppercased/Han characters.
@@ -73,7 +48,7 @@ public struct PrivateMessage: MessageWithBadges {
     /// User's name with no uppercased/Han characters.
     public var userLogin = String()
     /// The emotes present in the message.
-    public var emotes = [EmoteReference]()
+    public var emotes = [Emote]()
     /// Whether or not the message only contains emotes.
     public var emoteOnly = Bool()
     /// Flags of this message.
@@ -139,7 +114,7 @@ public struct PrivateMessage: MessageWithBadges {
         self.bits = parser.string(for: "bits")
         self.color = parser.string(for: "color")
         self.displayName = parser.string(for: "display-name")
-        self.emotes = parseEmotes(from: parser.string(for: "emotes"))
+        self.emotes = Emote.parse(from: parser.string(for: "emotes"), and: self.message)
         self.emoteOnly = parser.bool(for: "emote-only")
         self.flags = parser.array(for: "flags")
         self.firstMessage = parser.bool(for: "first-msg")
@@ -168,64 +143,10 @@ public struct PrivateMessage: MessageWithBadges {
             groupsOfExcludedUnavailableKeys: occasionalKeys
         )
     }
-
-    private func parseEmotes(from emoteString: String) -> [EmoteReference] {
-        /// First, we need to make sure we have an homogeneous array. In the message, emotes come as
-        /// a string that looks like `<id>:<start>-<end>/<id>:<start>-<end>`. However, when the same
-        /// emote repeats multiple times, it's more like
-        /// `<id>:<start>-<end>,<start>-<end>,<start>-<end>/<id>:<start>-<end>` and the parser has
-        /// issues giving it back as a list (the parser uses commas to sepparate, and doesn't take
-        /// the `/` into account).
-        ///
-        /// To solve this, we ask the parser to read it as a string and we treat the whole thing.
-        ///
-        /// Splitting by `/` returns an array like
-        /// `["<id>:<start>-<end>", "<start>-<end>", "<start>-<end>", "<id>:<start>-<end>"]`,
-        /// which makes it hard to treat all the elements the same since some of them have no `<id>`.
-        /// We solve this by using the last seen id as the id for elements that don't have one.
-        ///
-        /// Ater that, it's just a matter of parsing the indices and finding the equivalent text in
-        /// the chat message. With those, we can create our `EmoteReference` instance and save it.
-        var parsed: [EmoteReference] = []
-
-        let emoteArray = emoteString.split(separator: "/")
-            .flatMap { $0.split(separator: ",") }
-            .map { String($0) }
-
-        var lastID: String? = nil
-        for emote in emoteArray {
-            /// This gives us either `["<id>", "<start>", "<end>"]` or `["<start>", "<end>"]`
-            var parts = emote.split(separator: ":")
-                .flatMap { $0.split(separator: "-") }
-                .map { String($0) }
-
-            /// If we have an id, save it
-            if parts.count == 3 {
-                lastID = parts.removeFirst()
-            }
-
-            /// Try and retrieve the parts and add them to our list of emotes
-            if let lastID,
-                let startIndex = Int(parts[0]),
-                let endIndex = Int(parts[1]),
-                let name = message[stringIn: startIndex...endIndex]
-            {
-                parsed.append(.init(
-                    id: lastID,
-                    name: name,
-                    startIndex: startIndex,
-                    endIndex: endIndex
-                ))
-            }
-        }
-
-        return parsed
-    }
 }
 
 // MARK: - Sendable conformances
 #if swift(>=5.5)
 extension PrivateMessage: Sendable { }
-extension PrivateMessage.EmoteReference: Sendable { }
 extension PrivateMessage.ReplyParent: Sendable { }
 #endif

--- a/Sources/TwitchIRC/Utils/String Extensions.swift
+++ b/Sources/TwitchIRC/Utils/String Extensions.swift
@@ -156,4 +156,24 @@ extension RangeReplaceableCollection where Element == Character, Index == String
         
         return nil
     }
+
+    /// Subscripts a string using integers to create the equivalent indices.
+    subscript(range: ClosedRange<Int>) -> SubSequence? {
+        guard
+            let start = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
+            let end = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex)
+        else { return nil }
+
+        return self[start...end]
+    }
+
+    /// Subscripts a string using integers to create the equivalent indices.
+    subscript(stringIn range: ClosedRange<Int>) -> String? {
+        guard
+            let start = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
+            let end = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex)
+        else { return nil }
+
+        return String(self[start...end])
+    }
 }

--- a/Sources/TwitchIRC/Utils/String Extensions.swift
+++ b/Sources/TwitchIRC/Utils/String Extensions.swift
@@ -156,24 +156,4 @@ extension RangeReplaceableCollection where Element == Character, Index == String
         
         return nil
     }
-
-    /// Subscripts a string using integers to create the equivalent indices.
-    subscript(range: ClosedRange<Int>) -> SubSequence? {
-        guard
-            let start = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
-            let end = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex)
-        else { return nil }
-
-        return self[start...end]
-    }
-
-    /// Subscripts a string using integers to create the equivalent indices.
-    subscript(stringIn range: ClosedRange<Int>) -> String? {
-        guard
-            let start = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex),
-            let end = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex)
-        else { return nil }
-
-        return String(self[start...end])
-    }
 }

--- a/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
+++ b/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
@@ -7,6 +7,12 @@ final class PrivateMessageTests: XCTestCase {
         let string = "@badge-info=;badges=global_mod/1,turbo/1;color=#0D4200;display-name=ronni;emotes=25:0-4,12-16/1902:6-10;id=b34ccfc7-4977-403a-8a94-33c6bac34fb8;mod=0;room-id=1337;subscriber=0;tmi-sent-ts=1507246572675;turbo=1;user-id=1337;user-type=global_mod :ronni!ronni@ronni.tmi.twitch.tv PRIVMSG #ronni :Kappa Keepo Kappa"
         
         let msg: PrivateMessage = try TestUtils.parseAndUnwrap(string: string)
+
+        let emotes: [PrivateMessage.EmoteReference] = [
+            .init(id: "25", name: "Kappa", startIndex: 0, endIndex: 4),
+            .init(id: "25", name: "Kappa", startIndex: 12, endIndex: 16),
+            .init(id: "1902", name: "Keepo", startIndex: 6, endIndex: 10)
+        ]
         
         XCTAssertEqual(msg.channel, "ronni")
         XCTAssertEqual(msg.message, "Kappa Keepo Kappa")
@@ -16,7 +22,7 @@ final class PrivateMessageTests: XCTestCase {
         XCTAssertEqual(msg.color, "#0D4200")
         XCTAssertEqual(msg.displayName, "ronni")
         XCTAssertEqual(msg.userLogin, "ronni")
-        XCTAssertEqual(msg.emotes, ["25:0-4", "12-16/1902:6-10"])
+        XCTAssertEqual(msg.emotes, emotes)
         XCTAssertEqual(msg.emoteOnly, false)
         XCTAssertEqual(msg.flags, [])
         XCTAssertEqual(msg.firstMessage, false)

--- a/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
+++ b/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
@@ -245,6 +245,16 @@ final class PrivateMessageTests: XCTestCase {
     }
 }
 
+// MARK: - Emote Equatable
+extension Emote: Equatable {
+    public static func == (lhs: Emote, rhs: Emote) -> Bool {
+        lhs.id == rhs.id
+        && lhs.startIndex == rhs.startIndex
+        && lhs.endIndex == rhs.endIndex
+        && lhs.name == rhs.name
+    }
+}
+
 // MARK: - PrivateMessage.ReplyParent Equatable (basically)
 private func == (lhs: PrivateMessage.ReplyParent, rhs: PrivateMessage.ReplyParent) -> Bool {
     lhs.displayName == rhs.displayName

--- a/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
+++ b/Tests/TwitchIRCTests/IncomingMessageTests/PrivateMessageTests.swift
@@ -8,7 +8,7 @@ final class PrivateMessageTests: XCTestCase {
         
         let msg: PrivateMessage = try TestUtils.parseAndUnwrap(string: string)
 
-        let emotes: [PrivateMessage.EmoteReference] = [
+        let emotes: [Emote] = [
             .init(id: "25", name: "Kappa", startIndex: 0, endIndex: 4),
             .init(id: "25", name: "Kappa", startIndex: 12, endIndex: 16),
             .init(id: "1902", name: "Keepo", startIndex: 6, endIndex: 10)


### PR DESCRIPTION
Hi there!

I've been using your package for a personal project and it is great! Thank you very much for all the work. Since it has been very helpful, I thought I'd give back by improving something I found was not as straight forward as other aspects of the message.

Up to now, the parsing of the emotes in the message was a bit odd, specially for handling messages where the same emote repeats multiple times.

I made a small utility function that takes care of better parsing the information from the message into an array containing a new struct `EmoteReference`. This struct includes the id of the emote, the name (aka the text used to represent the emote), and the indices in the message that correspond to the emote. The idea is that having all this information it is easier for a user of the package to handle emotes.

Please, let me know if there's anything out of place or if I should include some more test cases (although I feel like the one included already handles all cases).

Cheers!